### PR TITLE
Fixes #33 - Update for Alfred4

### DIFF
--- a/src/workflow_config.rs
+++ b/src/workflow_config.rs
@@ -137,8 +137,9 @@ impl<'a> Config {
 
     pub fn is_alfred_v3(&self) -> bool {
         debug!("Starting in is_alfred_v3");
-        let r = VersionReq::parse("~3").expect("Couldn't parse ~3 version string");
-        r.matches(&self.alfred_version)
+        let v3 = VersionReq::parse("~3").expect("Couldn't parse ~3 version string");
+        let v4 = VersionReq::parse("~4").expect("Couldn't parse ~4 version string");
+        v3.matches(&self.alfred_version) || v4.matches(&self.alfred_version)
     }
 
     fn get_workflow_dirs() -> (PathBuf, PathBuf) {
@@ -167,6 +168,8 @@ fn get_alfred_version() -> Version {
             Version::parse(s).unwrap_or_else(|_| {
                 if s.starts_with("3.") {
                     Version::parse("3.0.0").expect("Parsing 3.0.0 shouldn't fail")
+                } else if s.starts_with("4."){
+                    Version::parse("4.0.0").expect("Parsing 4.0.0 shouldn't fail")
                 } else {
                     Version::parse("2.0.0").expect("Parsing 2.0.0 shouldn't fail")
                 }


### PR DESCRIPTION
This is a quick fix for Alfred 4. 

Note:
Alfred 4 uses the same json format as Alfred 3 so not much needed to be done. You might want to change the name of `is_alfred_v3()` function to something else now though. Maybe something like `takes_json_output` or `is_alfved_v3_or_v4` But that is a bigger change that wasn't totally necessary here. 