### PR TITLE
Show recent pins when no search param is given

### DIFF
--- a/res/workflow/info.plist
+++ b/res/workflow/info.plist
@@ -1996,7 +1996,7 @@ echo $ret
 				<key>argumenttrimmode</key>
 				<integer>0</integer>
 				<key>argumenttype</key>
-				<integer>0</integer>
+				<integer>1</integer>
 				<key>escaping</key>
 				<integer>126</integer>
 				<key>keyword</key>


### PR DESCRIPTION
Set 'Argument Optional' in the 'ps' command such that it returns the results from './alfred-pinboard-rs search $1' before searching (defaults to most recent pins)