### PR TITLE
use alfred-firefox workflow (if installed) to get the current URL from Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ When fuzzy search is enabled, the tags/bookmarks that contain the query letters 
 ---
 
 ## Known Issues<a name="known_issues"></a>
+- **Firefox**: If you have the [alfred-firefox workflow](https://github.com/deanishe/alfred-firefox) installed, this workflow will use it to get the current URL. In this case, tag suggestions and "Check if page is bookmarked" will work.
 - **Firefox**: While tag suggestions and "Check if page is bookmarked" options are enabled, posting bookmark from Firefox is broken. Deleting bookmarks using `pind` won't work when Firefox is your active browser. Reason: Firefox does not properly support interacting with it programatically.
 - If you get `cannot be opened because the developer cannot be verified.` error, check out [this issue](https://github.com/spamwax/alfred-pinboard-rs/issues/120) as well as the [post](https://www.alfredforum.com/topic/13824-workflow-fail-with-developer-cannot-be-verified-errors-in-catalina/?do=findComment&comment=72101) on Alfred forum
 - This workflow is setup to work with Aflred 4. It may or may not work with previous version as it has not been tested for them.

--- a/res/workflow/get-current-url-from-alfred-firefox.sh
+++ b/res/workflow/get-current-url-from-alfred-firefox.sh
@@ -1,4 +1,9 @@
 #!/bin/zsh
+#
+# Get the current URL from Firefox via the alfred-firefox workflow
+#
+# If that workflow is not installed, exits with no output;
+# then we fallback to grabbing the URL via clipboard
 
 ALFRED_FIREFOX="$(ls ../*/alfred-firefox | head -1)"
 if [[ -z "$ALFRED_FIREFOX" || ! -x "$ALFRED_FIREFOX" ]] ; then
@@ -6,4 +11,9 @@ if [[ -z "$ALFRED_FIREFOX" || ! -x "$ALFRED_FIREFOX" ]] ; then
 fi
 
 eval `"$ALFRED_FIREFOX" tab-info -shell`
+
+if [[ -z "$FF_URL" ]] ; then
+    exit
+fi
+
 echo "$FF_URL" fd850fc2e63511e79f720023dfdf24ec "$FF_TITLE"

--- a/res/workflow/get-current-url-from-alfred-firefox.sh
+++ b/res/workflow/get-current-url-from-alfred-firefox.sh
@@ -1,0 +1,9 @@
+#!/bin/zsh
+
+ALFRED_FIREFOX="$(ls ../*/alfred-firefox | head -1)"
+if [[ -z "$ALFRED_FIREFOX" || ! -x "$ALFRED_FIREFOX" ]] ; then
+    exit
+fi
+
+eval `"$ALFRED_FIREFOX" tab-info -shell`
+echo "$FF_URL" fd850fc2e63511e79f720023dfdf24ec "$FF_TITLE"

--- a/res/workflow/get-current-url.applescript
+++ b/res/workflow/get-current-url.applescript
@@ -162,6 +162,10 @@ on run
         set theText to item 2 of theResult
 
     else if theApplication is "Firefox.app" and appIsRunning("Firefox") then
+        set externalResult to do shell script "./get-current-url-from-alfred-firefox.sh"
+        if externalResult contains "fd850fc2e63511e79f720023dfdf24ec" then
+            return externalResult
+        end if
         set theResult to run script "tell application id \"org.mozilla.firefox\"
           activate
           set w to item 1 of window 1


### PR DESCRIPTION
The alfred-firefox workflow uses native messaging and a browser extension to integrate with Firefox. It provides a command-line client that talks to the plugin.

https://github.com/deanishe/alfred-firefox

This PR uses that client to get the current tab's URL from Firefox.

If the workflow is not installed, it falls back to using the existing behavior of "focus URL bar, copy text to clipboard"

I have tested the following:

- alfred-firefox not installed -- pinning a bookmark still works
- alfred-firefox is installed -- pinning a bookmark works
- alfred-firefox is installed -- with popular tags or check if bookmarked is enabled, pinning a bookmark now works (where previously it failed)
