### PR TITLE
Add support for the Kagi Orion browser

### DIFF
--- a/res/workflow/get-current-url.applescript
+++ b/res/workflow/get-current-url.applescript
@@ -127,6 +127,16 @@ on run
         end tell"
         set theURL to item 1 of theResult
         set theText to item 2 of theResult
+	
+    else if theApplication is "Orion.app" and appIsRunning("Orion") then
+        set theResult to run script "tell application id \"com.kagi.kagimacOS\"
+        set theTab to current tab of first window
+	set theUrl to URL of theTab
+	set theText to name of theTab
+	return {theUrl, theText}
+	end tell"
+        set theURL to item 1 of theResult
+        set theText to item 2 of theResult
 
     else if theApplication is "qutebrowser.app" and appIsRunning("qutebrowser") then
         set theResult to run script "tell application id \"org.qt-project.Qt.QtWebEngineCore\"


### PR DESCRIPTION
Adds the necessary AppleScript to work with the new (mac only!) [Orion browser](https://browser.kagi.com/). Tested by replacing the `get-current-url.applescript` file in my local workflow installation, and it worked as expected. 