### PR TITLE
chore(ci): Run tests for PRs and not macos-universal

### DIFF
--- a/.github/workflows/macos-universal.yml
+++ b/.github/workflows/macos-universal.yml
@@ -4,9 +4,6 @@ on:
       - master
     tags:
       - '*'
-  pull_request:
-    branches:
-      - master
   workflow_dispatch:
   # For quickly detecting important differences in runner configurations
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ on:
   push:
     branches:
       - develop
+  pull_request:
+    branches:
+      - master
   workflow_dispatch:
   # For quickly detecting important differences in runner configurations
 
@@ -16,7 +19,7 @@ jobs:
   build_universal:
     name: Run non-fat tests on ubuntu
     runs-on: ubuntu-latest
-    if: ${{ github.ref_type == 'branch' && github.ref_name == 'develop' }}
+    # if: ${{ github.ref_type == 'branch' && github.ref_name == 'develop' }}
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
- PRs do not (in general) to be tested using a fat universal, however they should be tested using x86 executable on Ubuntu.