### PR TITLE
Add Helium browser support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-01-15
+### Added
+- Add support for Helium browser in active tab detection.
+
 ## [0.17.1] - 2023-06-22
 ### Added
 - Add support for Arch browser

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ After initial [setup](#installation--setup):
 - Safari Tech. Preview
 - Brave Beta
 - Chrome
+- Helium
 
 ## Installation / Setup
 After [downloading](https://github.com/spamwax/alfred-pinboard-rs/releases/latest) the latest version of the workflow and installing it in Alfred, you need to do a one-time setup to authenticate the Workflow. This Workflow only uses username/token method so you won't need to enter your password. (This is the *suggested* way of using Pinboard's API).

--- a/res/workflow/get-current-url.applescript
+++ b/res/workflow/get-current-url.applescript
@@ -137,6 +137,26 @@ on run
 		set theURL to item 1 of theResult
 		set theText to item 2 of theResult
 		
+	else if theApplication is "Helium.app" and appIsRunning("Helium") then
+		try
+			tell application "System Events"
+				tell (first process whose name is "Helium")
+					set heliumWindow to front window
+					set theURL to value of attribute "AXDocument" of heliumWindow
+					if theURL is missing value then
+						set theURL to ""
+					else
+						set theURL to (theURL as text)
+					end if
+					set theText to name of heliumWindow
+					if theText is missing value then set theText to ""
+				end tell
+			end tell
+		on error
+			set theURL to ""
+			set theText to ""
+		end try
+		
 	else if theApplication is "Orion.app" and appIsRunning("Orion") then
 		set theResult to run script "tell application id \"com.kagi.kagimacOS\"
         set theTab to current tab of first window


### PR DESCRIPTION
- Adds Helium detection/URL capture to get-current-url.applescript. Helium doesn’t expose an AppleScript dictionary like Chrome/Safari, so we use System Events (Accessibility) to read the front Helium window’s AXDocument (URL) and window name (title), with fallbacks for missing values.
- Documents Helium in the supported browsers list.
- Records the addition in the changelog.